### PR TITLE
Add Shell Environment documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,10 @@ npm ci
 ## Type Checking
 TypeScript files are executed directly using tsx. No build step required.
 
+## Shell Environment
+- **ZSH Configuration**: When using zsh as default shell, manually run `source ~/.zshrc` to load shell configuration
+- Claude Code runs in non-interactive shell environment, so `.zshrc` is not automatically loaded
+
 ## Important Notes
 - Program exits if OpenAI API key is missing from environment variables
 - AWS credentials automatically loaded from ~/.aws/credentials or environment variables


### PR DESCRIPTION
## Summary
- Add Shell Environment section to CLAUDE.md documenting zsh configuration requirements
- Document that `.zshrc` needs manual loading in Claude Code's non-interactive shell environment

## Test plan
- [x] Verify CLAUDE.md contains new Shell Environment section
- [x] Confirm documentation is clear and accurate

🤖 Generated with [Claude Code](https://claude.ai/code)