### PR TITLE
Update OpenAI model to gpt-4o-mini

### DIFF
--- a/src/ai-handler.ts
+++ b/src/ai-handler.ts
@@ -102,7 +102,7 @@ export class AIHandler {
   async chat(messages: ChatMessage[]): Promise<OpenAI.Chat.Completions.ChatCompletion> {
     try {
       const response = await this.openai.chat.completions.create({
-        model: "gpt-4",
+        model: "gpt-4o-mini",
         messages,
         tools: this.tools,
         tool_choice: "auto"
@@ -139,7 +139,7 @@ export class AIHandler {
         ];
 
         return await this.openai.chat.completions.create({
-          model: "gpt-4",
+          model: "gpt-4o-mini",
           messages: followUpMessages
         });
       }


### PR DESCRIPTION
## Summary
- Changes default OpenAI model from gpt-4 to gpt-4o-mini in AIHandler class
- Applies to both initial chat completion and follow-up tool responses  
- More cost-effective model while maintaining functionality

## Test plan
- [x] Verify TypeScript compilation passes
- [ ] Test chat functionality with new model
- [ ] Verify tool calling still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)